### PR TITLE
Add configuration file support via ~/.llmcatrc

### DIFF
--- a/llmcat
+++ b/llmcat
@@ -2,10 +2,26 @@
 
 # Config
 set -eo pipefail
+
+# Default configuration values
 CLIP_CMD=""
 VERSION="1.0.0"
 QUIET="true"
 DEBUG="false"
+
+custom_ignores=""  # default ignore patterns if any
+tree_only="false"
+
+# -- New: Load configuration file --
+# Allow overriding the default config file path via LLMCAT_CONFIG env variable
+CONFIG_FILE="${LLMCAT_CONFIG:-$HOME/.llmcatrc}"
+if [ -f "$CONFIG_FILE" ]; then
+    # Optionally, you can print a debug message if DEBUG is enabled
+    # (If DEBUG isn’t set yet, you can always echo or remove this line)
+    echo "Loading configuration from $CONFIG_FILE" >&2
+    source "$CONFIG_FILE"
+fi
+# -----------------------------------
 
 # Help text
 show_help() {
@@ -18,11 +34,11 @@ Usage: llmcat [options] [path]
 Options:
     -h, --help              Show this help message
     -i, --ignore PATTERN    Additional ignore patterns (grep -E format)
-    -v, --version          Show version
-    -t, --tree-only        Only output directory tree
-    -q, --quiet            Silent mode (only copy to clipboard)
-    -p, --print            Print copied files/content (default: quiet)
-    --debug                Enable debug output
+    -v, --version           Show version
+    -t, --tree-only         Only output directory tree
+    -q, --quiet             Silent mode (only copy to clipboard)
+    -p, --print             Print copied files/content (default: quiet)
+    --debug                 Enable debug output
 
 Interactive Mode (fzf):
     tab          - Select/mark multiple files


### PR DESCRIPTION
### Overview

This PR introduces configuration file support to the llmcat script. Users can now customize default settings without passing command-line options every time they run the tool.

### Changes Made

- **Configuration File Loading:**  
  - The script checks for a configuration file at the location specified by the environment variable `LLMCAT_CONFIG`. If not set, it defaults to `$HOME/.llmcatrc`.
  - If the file exists, it is sourced at the start of the script, allowing users to override default variables (e.g., `QUIET`, `DEBUG`, `custom_ignores`, etc.).

- **Usage Example:**  
  - Users can create a `~/.llmcatrc` file with their custom settings:
    ```bash
    # ~/.llmcatrc
    QUIET="false"
    custom_ignores="*.log|*.tmp"
    DEBUG="true"
    ```
  - These settings will be automatically loaded when llmcat is executed.

### Benefits

- **User Customization:**  
  Provides a flexible way for users to persistently set their preferences without needing to specify them on every invocation.
- **Simplified Command-Line Usage:**  
  Reduces the need for repetitive flags and arguments, streamlining the command-line experience.

### Future Work

This feature lays the groundwork for additional enhancements (e.g., extended configuration options, more advanced defaults, etc.) that can be built upon in future PRs.

Please review and let me know if any changes are needed. Thanks!