### PR TITLE
Added wl-copy to linux clip cmds

### DIFF
--- a/llmcat
+++ b/llmcat
@@ -81,7 +81,9 @@ detect_os() {
             }
             ;;
         "Linux")
-            if command -v xclip >/dev/null 2>&1; then
+            if command -v wl-copy >/dev/null 2>&1; then
+                CLIP_CMD="wl-copy"
+            elif command -v xclip >/dev/null 2>&1; then
                 CLIP_CMD="xclip -selection clipboard"
             elif command -v xsel >/dev/null 2>&1; then
                 CLIP_CMD="xsel --clipboard --input"


### PR DESCRIPTION
I use wayland and the replacement for xclip there is [wl-clipboard](https://github.com/bugaevc/wl-clipboard), so this is just a tiny change that adds `wl-copy` as a clipboard command.