### PR TITLE
proposal: replace find with fd

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/user-attachments/assets/4354459f-be48-41f5-b6e4-2f00fa78d40d" width="200" />
 
 
-Fast and flexible tool for copying files to large language models from command-line, supporting fuzzy search, multi-file selection and respecting `.gitignore` rules.
+Fast and flexible tool for copying files to large language models from command-line, supporting fuzzy search, multi-file selection and automatically respecting `.gitignore` rules.
 
 ```bash
 # Copy specific file
@@ -43,9 +43,11 @@ chmod +x llmcat
 sudo mv llmcat /usr/local/bin/
 ```
 
-Required for interactive mode:
-* fzf
-* bat
+Required dependencies:
+* fd (for file discovery)
+* ripgrep (for text operations)
+* fzf (for interactive selection)
+* bat (for file preview in interactive mode)
 
 ## Usage
 
@@ -77,8 +79,17 @@ $ llmcat src/main.rs
 # Copy directory
 $ llmcat src/
 
-# Ignore specific files
+# Ignore specific files (uses fd glob patterns)
 $ llmcat -i "*.log" ./src/
+
+# Ignore multiple patterns
+$ llmcat -i "*.log" -i "*.tmp" ./src/
+
+# Don't respect gitignore files
+$ llmcat -n ./src/
+
+# Include hidden files/directories
+$ llmcat -H ./src/
 
 # Print output while copying
 $ llmcat -p file.txt
@@ -97,12 +108,14 @@ Usage: llmcat [options] [path]
 
 Options:
     -h, --help              Show this help message
-    -i, --ignore PATTERN    Additional ignore patterns (grep -E format)
-    -v, --version          Show version
-    -t, --tree-only        Only output directory tree
-    -q, --quiet            Silent mode (only copy to clipboard)
-    -p, --print            Print copied files/content (default: quiet)
-    --debug                Enable debug output
+    -i, --ignore PATTERN    Additional ignore patterns (fd exclude format: glob pattern)
+    -v, --version           Show version
+    -t, --tree-only         Only output directory tree
+    -q, --quiet             Silent mode (only copy to clipboard)
+    -p, --print             Print copied files/content (default: quiet)
+    -n, --no-ignore         Don't respect gitignore/ignore files
+    -H, --hidden            Include hidden files/directories
+    --debug                 Enable debug output
 
 Interactive Mode (fzf):
     tab          - Select/mark multiple files
@@ -121,7 +134,7 @@ Examples:
     llmcat path/to/file.txt
 
     # Process directory with custom ignore
-    llmcat -i "*.log|*.tmp" ./src/
+    llmcat -i "*.log" -i "*.tmp" ./src/
 
     # Print content while copying
     llmcat -p ./src/file.txt
@@ -129,8 +142,15 @@ Examples:
 Features:
     - Interactive fuzzy finder with file preview
     - Auto-copies output to clipboard
-    - Respects .gitignore
+    - Automatically respects .gitignore, .ignore, and .fdignore files
     - Directory tree visualization
     - Multi-file selection
     - Cross-platform (Linux/OSX)
 ```
+
+## Behavior Changes from v1.x
+
+- Uses `fd` instead of `find`, automatically respecting `.gitignore` files
+- Hidden files/directories are excluded by default (unlike `find`)
+- Match patterns now use fd's glob syntax instead of grep patterns
+- Uses ripgrep for faster text operations

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ sudo mv llmcat /usr/local/bin/
 
 Required dependencies:
 * fd (for file discovery)
-* ripgrep (for text operations)
 * fzf (for interactive selection)
-* bat (for file preview in interactive mode)
+* bat (for file preview in interactive mode) (optional)
 
 ## Usage
 
@@ -153,4 +152,3 @@ Features:
 - Uses `fd` instead of `find`, automatically respecting `.gitignore` files
 - Hidden files/directories are excluded by default (unlike `find`)
 - Match patterns now use fd's glob syntax instead of grep patterns
-- Uses ripgrep for faster text operations

--- a/llmcat
+++ b/llmcat
@@ -3,7 +3,7 @@
 # Config
 set -eo pipefail
 CLIP_CMD=""
-VERSION="1.0.0"
+VERSION="2.0.0"
 QUIET="true"
 DEBUG="false"
 
@@ -17,12 +17,14 @@ Usage: llmcat [options] [path]
 
 Options:
     -h, --help              Show this help message
-    -i, --ignore PATTERN    Additional ignore patterns (grep -E format)
-    -v, --version          Show version
-    -t, --tree-only        Only output directory tree
-    -q, --quiet            Silent mode (only copy to clipboard)
-    -p, --print            Print copied files/content (default: quiet)
-    --debug                Enable debug output
+    -i, --ignore PATTERN    Additional ignore patterns (fd exclude format)
+    -v, --version           Show version
+    -t, --tree-only         Only output directory tree
+    -q, --quiet             Silent mode (only copy to clipboard)
+    -p, --print             Print copied files/content (default: quiet)
+    -n, --no-ignore         Don't respect gitignore/ignore files
+    -H, --hidden            Include hidden files/directories
+    --debug                 Enable debug output
 
 Interactive Mode (fzf):
     tab          - Select/mark multiple files
@@ -41,7 +43,7 @@ Examples:
     llmcat path/to/file.txt
 
     # Process directory with custom ignore
-    llmcat -i "*.log|*.tmp" ./src/
+    llmcat -i "*.log" -i "*.tmp" ./src/
 
     # Print content while copying
     llmcat -p ./src/file.txt
@@ -49,10 +51,16 @@ Examples:
 Features:
     - Interactive fuzzy finder with file preview
     - Auto-copies output to clipboard
-    - Respects .gitignore
+    - Automatically respects .gitignore, .ignore, and .fdignore files
     - Directory tree visualization
     - Multi-file selection
     - Cross-platform (Linux/OSX)
+
+Behavior Changes from v1.x:
+    - Uses fd instead of find, automatically respecting .gitignore files
+    - Hidden files/directories are excluded by default (unlike find)
+    - Match patterns now use fd's syntax instead of grep patterns
+    - Uses ripgrep for faster text operations
 
 Author:
     Azer Koculu (https://azerkoculu.com)
@@ -108,44 +116,40 @@ find_root() {
     fi
 }
 
-# Check for fzf and configure it
-setup_fzf() {
+# Check for dependencies
+check_dependencies() {
+    local missing=false
+
+    if ! command -v fd >/dev/null 2>&1; then
+        echo "Interactive mode requires fd. Install with:"
+        echo "  brew install fd    # macOS"
+        echo "  apt install fd-find     # Ubuntu (available as 'fdfind')"
+        echo "  https://github.com/sharkdp/fd#installation"
+        missing=true
+    fi
+
+    if ! command -v rg >/dev/null 2>&1; then
+        echo "Interactive mode requires ripgrep. Install with:"
+        echo "  brew install ripgrep    # macOS"
+        echo "  apt install ripgrep     # Ubuntu"
+        echo "  https://github.com/BurntSushi/ripgrep#installation"
+        missing=true
+    fi
+    
     if ! command -v fzf >/dev/null 2>&1; then
         echo "Interactive mode requires fzf. Install with:"
         echo "  brew install fzf    # macOS"
         echo "  apt install fzf     # Ubuntu"
         echo
-        show_help
-        return 1
+        missing=true
     fi
-    return 0
-}
 
-# Parse .gitignore into grep pattern
-parse_gitignore() {
-    local gitignore="$1"
-    if [ -f "$gitignore" ]; then
-        grep -v '^#' "$gitignore" | \
-        grep -v '^\s*$' | \
-        sed 's/\./\\./g' | \
-        sed 's/\*/[^\/]*/g' | \
-        tr '\n' '|' | \
-        sed 's/|$//'
-    fi
-}
-
-# Get relative path from root
-get_relative_path() {
-    local path="$1"
-    local root_dir
-    root_dir=$(find_root)
-    echo "${path#$root_dir/}"
+    [ "$missing" = "true" ] && return 1 || return 0
 }
 
 # Run fzf with configuration
 run_fzf() {
-    local gitignore_pattern="$1"
-    local custom_ignores="$2"
+    local fd_opts="$1"
     local root_dir
     root_dir=$(find_root)
 
@@ -154,7 +158,7 @@ run_fzf() {
     # Preview script to handle files vs directories
     local preview_cmd='
         if [ -f {} ]; then
-            bat --style=numbers --color=always {} 2>/dev/null
+            bat --style=numbers --color=always {} 2>/dev/null || cat {}
         elif [ -d {} ]; then
             echo "\n  Directory: {}\n"
             tree -C {} 2>/dev/null || ls -la {} 2>/dev/null
@@ -162,19 +166,17 @@ run_fzf() {
 
     # Change to root directory temporarily
     (cd "$root_dir" && {
-        local find_cmd="find . -type f -o -type d"
-        [ -n "$gitignore_pattern" ] && find_cmd+=" | grep -Ev \"$gitignore_pattern\""
-        [ -n "$custom_ignores" ] && find_cmd+=" | grep -Ev \"$custom_ignores\""
+        local fd_cmd="fd . --color=never $fd_opts"
+        
+        debug "Fd command: $fd_cmd"
 
-        debug "Find command: $find_cmd"
-
-        # Remove leading ./ from paths
-        eval "$find_cmd" | sed 's|^\./||' | fzf \
+        # Execute fd command and pipe to fzf
+        eval "$fd_cmd" | fzf \
             --preview "$preview_cmd" \
             --preview-window 'right:60%:border-left' \
             --bind 'ctrl-/:toggle-preview' \
-            --bind 'ctrl-d:change-prompt(Select directories > )+reload(find . -type d | sed "s|^./||")' \
-            --bind 'ctrl-f:change-prompt(Select files > )+reload(find . -type f | sed "s|^./||")' \
+            --bind "ctrl-d:change-prompt(Select directories > )+reload(fd . --type directory --color=never $fd_opts)" \
+            --bind "ctrl-f:change-prompt(Select files > )+reload(fd . --type file --color=never $fd_opts)" \
             --bind 'tab:toggle+up' \
             --height '80%' \
             --border=rounded \
@@ -184,6 +186,13 @@ run_fzf() {
     })
 }
 
+# Get relative path from root
+get_relative_path() {
+    local path="$1"
+    local root_dir
+    root_dir=$(find_root)
+    echo "${path#$root_dir/}"
+}
 
 # Process file content
 process_file() {
@@ -201,13 +210,10 @@ process_file() {
 # Process directory content
 process_dir() {
     local dir="$1"
-    local custom_ignores="$2"
+    local fd_opts="$2"
     local tree_only="$3"
-    local gitignore_pattern=""
     local rel_path
     rel_path=$(get_relative_path "$dir")
-
-    [ -f "$dir/.gitignore" ] && gitignore_pattern=$(parse_gitignore "$dir/.gitignore")
 
     {
         echo "# Directory: $rel_path"
@@ -217,39 +223,26 @@ process_dir() {
         # Tree output
         local tree_output
         if command -v tree >/dev/null 2>&1; then
-            tree_output=$(cd "$dir" && tree -I "$(echo "$gitignore_pattern" | tr '|' ' ')")
+            # Use tree command if available with ignore patterns
+            tree_output=$(cd "$dir" && tree)
         else
-            tree_output=$(find "$dir" -type f -o -type d 2>/dev/null | \
-            if [ -n "$gitignore_pattern" ]; then
-                grep -Ev "$gitignore_pattern"
-            else
-                cat
-            fi | \
-            if [ -n "$custom_ignores" ]; then
-                grep -Ev "$custom_ignores"
-            else
-                cat
-            fi | \
-            sed -e "s/[^-][^\/]*\// |--/g" -e "s/|\([^ ]\)/|-\1/")
+            # Use fd to simulate a tree view
+            local fd_tree_cmd="cd \"$dir\" && fd . --color=never $fd_opts"
+            
+            # Create tree-like output with sed
+            tree_output=$(eval "$fd_tree_cmd" | sed -e "s/[^-][^\/]*\// |--/g" -e "s/|\([^ ]\)/|-\1/")
         fi
         echo "$tree_output"
 
         # Process files only if not tree_only
         if [ "$tree_only" != "true" ]; then
-            find "$dir" -type f 2>/dev/null | \
-            if [ -n "$gitignore_pattern" ]; then
-                grep -Ev "$gitignore_pattern"
-            else
-                cat
-            fi | \
-            if [ -n "$custom_ignores" ]; then
-                grep -Ev "$custom_ignores"
-            else
-                cat
-            fi | \
-            while IFS= read -r file; do
+            # Find all files with fd
+            local fd_files_cmd="cd \"$dir\" && fd . --type file --color=never $fd_opts"
+            
+            # Process each file
+            eval "$fd_files_cmd" | while IFS= read -r file; do
                 echo
-                process_file "$file"
+                process_file "$dir/$file"
             done
         fi
     }
@@ -270,7 +263,7 @@ output_handler() {
     # Show feedback only for file copies, not tree-only mode
     if [ "$tree_only" != "true" ]; then
         local file_count
-        file_count=$(echo "$content" | grep -c "^## File:" || true)
+        file_count=$(echo "$content" | rg -c "^## File:" || true)
         echo "Copied $file_count file(s) to clipboard" >&2
     fi
 }
@@ -279,13 +272,15 @@ output_handler() {
 process_targets() {
     local output=""
     local target
+    local fd_opts="$1"
+    shift
 
     for target in "$@"; do
         debug "Processing: $target"
         if [ -f "$target" ]; then
             output+="$(process_file "$target")"
         elif [ -d "$target" ]; then
-            output+="$(process_dir "$target" "$custom_ignores" "$tree_only")"
+            output+="$(process_dir "$target" "$fd_opts" "$tree_only")"
         else
             echo "Warning: Target not found - $target" >&2
             continue
@@ -297,7 +292,7 @@ process_targets() {
 }
 
 main() {
-    local custom_ignores=""
+    local fd_opts=""
     local tree_only="false"
     local targets=()
 
@@ -306,12 +301,30 @@ main() {
         case $1 in
             -h|--help) show_help; exit 0 ;;
             -v|--version) echo "llmcat version $VERSION"; exit 0 ;;
-            -i|--ignore) custom_ignores="$2"; shift 2 ;;
-            -t|--tree-only) tree_only="true"; shift ;;
-            -q|--quiet) QUIET="true"; shift ;;
-            -p|--print) QUIET="false"; shift ;;
-            --debug) DEBUG="true"; shift ;;
-            *) targets+=("$1"); shift ;;
+            -i|--ignore) 
+                fd_opts+=" --exclude \"$2\""; 
+                shift 2 ;;
+            -n|--no-ignore) 
+                fd_opts+=" --no-ignore"; 
+                shift ;;
+            -H|--hidden) 
+                fd_opts+=" --hidden"; 
+                shift ;;
+            -t|--tree-only) 
+                tree_only="true"; 
+                shift ;;
+            -q|--quiet) 
+                QUIET="true"; 
+                shift ;;
+            -p|--print) 
+                QUIET="false"; 
+                shift ;;
+            --debug) 
+                DEBUG="true"; 
+                shift ;;
+            *) 
+                targets+=("$1"); 
+                shift ;;
         esac
     done
 
@@ -320,13 +333,10 @@ main() {
     # Interactive mode if no targets
     if [ ${#targets[@]} -eq 0 ]; then
         debug "Starting interactive mode"
-        if setup_fzf; then
-            local gitignore_pattern=""
-            [ -f ".gitignore" ] && gitignore_pattern=$(parse_gitignore ".gitignore")
-
+        if check_dependencies; then
             debug "Running fzf selection"
             local selected
-            selected=$(run_fzf "$gitignore_pattern" "$custom_ignores")
+            selected=$(run_fzf "$fd_opts")
 
             if [ -n "$selected" ]; then
                 debug "Processing selection"
@@ -344,7 +354,7 @@ main() {
 
     if [ ${#targets[@]} -gt 0 ]; then
         debug "Processing ${#targets[@]} targets"
-        process_targets "${targets[@]}"
+        process_targets "$fd_opts" "${targets[@]}"
     fi
 }
 

--- a/llmcat
+++ b/llmcat
@@ -6,6 +6,7 @@ CLIP_CMD=""
 VERSION="2.0.0"
 QUIET="true"
 DEBUG="false"
+FILE_COUNT=0  # Initialize the file counter
 
 # Help text
 show_help() {
@@ -200,6 +201,7 @@ process_file() {
     local file="$1"
     local rel_path
     rel_path=$(get_relative_path "$file")
+    # Note: Don't increment counter here since this runs in a subshell
     {
         echo "## File: $rel_path"
         echo "---"
@@ -263,9 +265,7 @@ output_handler() {
 
     # Show feedback only for file copies, not tree-only mode
     if [ "$tree_only" != "true" ]; then
-        local file_count
-        file_count=$(echo "$content" | rg -c "^## File:" || true)
-        echo "Copied $file_count file(s) to clipboard" >&2
+        echo "Copied $FILE_COUNT file(s) to clipboard" >&2
     fi
 }
 
@@ -276,11 +276,22 @@ process_targets() {
     local fd_opts="$1"
     shift
 
+    # Reset file counter before processing
+    FILE_COUNT=0
+    
     for target in "$@"; do
         debug "Processing: $target"
         if [ -f "$target" ]; then
+            FILE_COUNT=$((FILE_COUNT + 1))
             output+="$(process_file "$target")"
         elif [ -d "$target" ]; then
+            # For directories, we need to count the files inside
+            if [ "$tree_only" != "true" ]; then
+                # Count files in directory
+                local file_count_in_dir
+                file_count_in_dir=$(cd "$target" && fd . --type file --color=never $fd_opts | wc -l)
+                FILE_COUNT=$((FILE_COUNT + file_count_in_dir))
+            fi
             output+="$(process_dir "$target" "$fd_opts" "$tree_only")"
         else
             echo "Warning: Target not found - $target" >&2

--- a/llmcat
+++ b/llmcat
@@ -18,7 +18,7 @@ Usage: llmcat [options] [path]
 
 Options:
     -h, --help              Show this help message
-    -i, --ignore PATTERN    Additional ignore patterns (fd exclude format)
+    -i, --ignore PATTERN    Additional ignore patterns (fd exclude format: glob pattern)
     -v, --version           Show version
     -t, --tree-only         Only output directory tree
     -q, --quiet             Silent mode (only copy to clipboard)

--- a/llmcat
+++ b/llmcat
@@ -61,7 +61,6 @@ Behavior Changes from v1.x:
     - Uses fd instead of find, automatically respecting .gitignore files
     - Hidden files/directories are excluded by default (unlike find)
     - Match patterns now use fd's syntax instead of grep patterns
-    - Uses ripgrep for faster text operations
 
 Author:
     Azer Koculu (https://azerkoculu.com)
@@ -129,14 +128,6 @@ check_dependencies() {
         missing=true
     fi
 
-    if ! command -v rg >/dev/null 2>&1; then
-        echo "Interactive mode requires ripgrep. Install with:"
-        echo "  brew install ripgrep    # macOS"
-        echo "  apt install ripgrep     # Ubuntu"
-        echo "  https://github.com/BurntSushi/ripgrep#installation"
-        missing=true
-    fi
-    
     if ! command -v fzf >/dev/null 2>&1; then
         echo "Interactive mode requires fzf. Install with:"
         echo "  brew install fzf    # macOS"

--- a/llmcat
+++ b/llmcat
@@ -170,12 +170,13 @@ run_fzf() {
         
         debug "Fd command: $fd_cmd"
 
-        # Execute fd command and pipe to fzf
-        eval "$fd_cmd" | fzf \
+        # Execute fd command and pipe to fzf, adding the current directory
+        # to maintain original behavior
+        (echo "."; eval "$fd_cmd") | fzf \
             --preview "$preview_cmd" \
             --preview-window 'right:60%:border-left' \
             --bind 'ctrl-/:toggle-preview' \
-            --bind "ctrl-d:change-prompt(Select directories > )+reload(fd . --type directory --color=never $fd_opts)" \
+            --bind "ctrl-d:change-prompt(Select directories > )+reload(echo \".\"; fd . --type directory --color=never $fd_opts)" \
             --bind "ctrl-f:change-prompt(Select files > )+reload(fd . --type file --color=never $fd_opts)" \
             --bind 'tab:toggle+up' \
             --height '80%' \


### PR DESCRIPTION
I initially just wanted to improve the .gitignore handling which currently doesn't work really well because it's implemented by parsing the gitignore and creating grep patterns from it. This misses a few gitignore patterns and also ignores global git ignores. I found that implementing this manually actually added a lot of complexity.

This is where I ended up replacing find with fd which is .gitignore aware and has it's own .fdignore file. It also excludes hidden directories by default. And in my testing is much faster. In my personal use, I ended up finding it much faster than the previous implementation. I don't think that's really important since at the size where it would matter, the size of the files would blow the context limit of any models out there, but it's still neat. 

In the end this pushes most of the complexity of file searching, exclusion, etc to fd. 

I also replaced the file count with a counter instead of running grep on the final output.

This does make this script much less portable with a more esoteric dependency, but one I think most people have(?). I am not entirely sure whether you would want to merge this many changes that might have some behaviour changes that might affect you. 

I leave it up to you. If you don't merge it, I could live with my changes and rename my repo if you would prefer. Thanks for the initial implementation, appreciated it for quick and dirty contexts to llms.