### PR TITLE
fix: use env-based shebang for portability

### DIFF
--- a/llmcat
+++ b/llmcat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Config
 set -eo pipefail


### PR DESCRIPTION
Updates the shebang in the llmcat script from `#!/bin/bash` to `#!/usr/bin/env bash` for improved portability across different systems.